### PR TITLE
put container in header

### DIFF
--- a/src/content-handlers/iiif/modules/uv-pagingheaderpanel-module/PagingHeaderPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-pagingheaderpanel-module/PagingHeaderPanel.ts
@@ -12,7 +12,7 @@ import { Canvas, LanguageMap, ManifestType } from "manifesto.js";
 import { Config } from "../../extensions/uv-openseadragon-extension/config/Config";
 import { createElement } from "react";
 import PagingHeaderPanelLeftOptions from "./PagingHeaderPanelLeftOptions";
-import PagingHeaderPanelRightOptions from "./PagingHeaderPanelRightOptions";
+// import PagingHeaderPanelRightOptions from "./PagingHeaderPanelRightOptions";
 
 export class PagingHeaderPanel extends HeaderPanel<
   Config["modules"]["pagingHeaderPanel"]
@@ -464,9 +464,9 @@ export class PagingHeaderPanel extends HeaderPanel<
       createElement(PagingHeaderPanelLeftOptions, {})
     );
 
-    this.rightOptionsRoot.render(
-      createElement(PagingHeaderPanelRightOptions, {})
-    );
+    // this.rightOptionsRoot.render(
+    //   createElement(PagingHeaderPanelRightOptions, {})
+    // );
   }
 
   openGallery(): void {

--- a/src/content-handlers/iiif/modules/uv-pagingheaderpanel-module/PagingHeaderPanelRightOptions.tsx
+++ b/src/content-handlers/iiif/modules/uv-pagingheaderpanel-module/PagingHeaderPanelRightOptions.tsx
@@ -1,7 +1,7 @@
-import React from "react";
+// import React from "react";
 
-const PagingHeaderPanelRightOptions = () => {
-  return <div>right options go here</div>;
-};
+// const PagingHeaderPanelRightOptions = () => {
+//   return <div>right options go here</div>;
+// };
 
-export default PagingHeaderPanelRightOptions;
+// export default PagingHeaderPanelRightOptions;

--- a/src/content-handlers/iiif/modules/uv-pdfheaderpanel-module/PDFHeaderPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-pdfheaderpanel-module/PDFHeaderPanel.ts
@@ -6,7 +6,7 @@ import { HeaderPanel } from "../uv-shared-module/HeaderPanel";
 import { Strings } from "@edsilv/utils";
 import { createElement } from "react";
 import PDFHeaderPanelLeftOptions from "./PDFHeaderPanelLeftOptions";
-import PDFHeaderPanelRightOptions from "./PDFHeaderPanelRightOptions";
+// import PDFHeaderPanelRightOptions from "./PDFHeaderPanelRightOptions";
 
 export class PDFHeaderPanel extends HeaderPanel<
   Config["modules"]["pdfHeaderPanel"]
@@ -150,7 +150,7 @@ export class PDFHeaderPanel extends HeaderPanel<
     //render PDF options react components in roots
     this.leftOptionsRoot.render(createElement(PDFHeaderPanelLeftOptions, {}));
 
-    this.rightOptionsRoot.render(createElement(PDFHeaderPanelRightOptions, {}));
+    // this.rightOptionsRoot.render(createElement(PDFHeaderPanelRightOptions, {}));
   }
 
   render(): void {

--- a/src/content-handlers/iiif/modules/uv-pdfheaderpanel-module/PDFHeaderPanelRightOptions.tsx
+++ b/src/content-handlers/iiif/modules/uv-pdfheaderpanel-module/PDFHeaderPanelRightOptions.tsx
@@ -1,7 +1,7 @@
-import React from "react";
+// import React from "react";
 
-const PDFHeaderPanelRightOptions = () => {
-  return <div className="text-white">PDF right options go here</div>;
-};
+// const PDFHeaderPanelRightOptions = () => {
+//   return <div className="text-white">PDF right options go here</div>;
+// };
 
-export default PDFHeaderPanelRightOptions;
+// export default PDFHeaderPanelRightOptions;

--- a/src/content-handlers/iiif/modules/uv-shared-module/HeaderPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/HeaderPanel.ts
@@ -13,7 +13,6 @@ import { Root, createRoot } from "react-dom/client";
 import { createElement } from "react";
 import HeaderPanelRightOptions from "./HeaderPanelRightOptions";
 
-
 export class HeaderPanel<
   T extends BaseConfig["modules"]["headerPanel"]
 > extends BaseView<T> {
@@ -233,11 +232,7 @@ export class HeaderPanel<
       }
     }
 
-    this.rightOptionsRoot.render(
-      createElement(HeaderPanelRightOptions, {}
-      )
-    )
-  
+    this.rightOptionsRoot.render(createElement(HeaderPanelRightOptions, {}));
 
     // hide toggle buttons below minimum width
     if (this.extension.isMobileMetric()) {

--- a/src/content-handlers/iiif/modules/uv-shared-module/HeaderPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/HeaderPanel.ts
@@ -10,6 +10,9 @@ import { Bools } from "@edsilv/utils";
 import { isVisible } from "../../../../Utils";
 import { BaseConfig } from "../../BaseConfig";
 import { Root, createRoot } from "react-dom/client";
+import { createElement } from "react";
+import HeaderPanelRightOptions from "./HeaderPanelRightOptions";
+
 
 export class HeaderPanel<
   T extends BaseConfig["modules"]["headerPanel"]
@@ -229,6 +232,12 @@ export class HeaderPanel<
         $message.text(this.information.message);
       }
     }
+
+    this.rightOptionsRoot.render(
+      createElement(HeaderPanelRightOptions, {}
+      )
+    )
+  
 
     // hide toggle buttons below minimum width
     if (this.extension.isMobileMetric()) {

--- a/src/content-handlers/iiif/modules/uv-shared-module/HeaderPanelRightOptions.tsx
+++ b/src/content-handlers/iiif/modules/uv-shared-module/HeaderPanelRightOptions.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const HeaderPanelRightOptions = () => {
+  return <div className="text-white">right options test</div>;
+};
+
+export default HeaderPanelRightOptions;


### PR DESCRIPTION
Added right panel options container to regular headerpanel instead of pagingheaderpanel so that it works for all file formats. Commented out the container in pagingheaderpanel for now - might be better to completely remove if no longer needed? 